### PR TITLE
Demo: update link to "task source" in Async action

### DIFF
--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -72,7 +72,7 @@
     <p>
       Uses async action, driven by <a href="http://ember-concurrency.com/">ember-concurrency</a>.
 
-      See <a href="https://github.com/kaliber5/ember-drag-sort/blob/gen-0/tests/dummy/app/controllers/index.js#L69-L82">task source</a>.
+      See <a href="https://github.com/kaliber5/ember-drag-sort/blob/gen-1/tests/dummy/app/controllers/index.js#L158-L177">task source</a>.
     </p>
 
     <p>


### PR DESCRIPTION
The link has an anchor to lines in the code. Code probably moved but the link wasn't updated to point the task source properly.

It is fixed with this PR.