### PR TITLE
Don't show not-allowed cursor on valid drop targets.

### DIFF
--- a/addon/components/drag-sort-item.js
+++ b/addon/components/drag-sort-item.js
@@ -265,6 +265,7 @@ export default Component.extend({
         : (mousePosition - offset) < (itemSize + placeholderCorrection) / 2
 
     dragSort.draggingOver({group, index, items, isDraggingUp})
+    event.preventDefault();
   },
 
   collapse () {

--- a/addon/components/drag-sort-item.js
+++ b/addon/components/drag-sort-item.js
@@ -183,6 +183,7 @@ export default Component.extend({
     if (group !== activeGroup) return
 
     event.stopPropagation()
+    event.preventDefault()
 
     this.draggingOver(event)
   },
@@ -265,7 +266,6 @@ export default Component.extend({
         : (mousePosition - offset) < (itemSize + placeholderCorrection) / 2
 
     dragSort.draggingOver({group, index, items, isDraggingUp})
-    event.preventDefault();
   },
 
   collapse () {


### PR DESCRIPTION
This is a fix proposal for my issue #28.