### PR TITLE
Avoid redirects to anything.com in Firefox.

### DIFF
--- a/addon/components/drag-sort-item.js
+++ b/addon/components/drag-sort-item.js
@@ -166,8 +166,14 @@ export default Component.extend({
     if (!this.get('dragSort.isDragging')) return
 
     event.stopPropagation()
+    event.preventDefault()
 
     this.endDragging(event)
+  },
+
+  // Required for Firefox. http://stackoverflow.com/a/32592759/901944
+  drop (event) {
+    event.preventDefault()
   },
 
   dragOver (event) {


### PR DESCRIPTION
See http://stackoverflow.com/a/32592759/901944

If you don't `preventDefault`, the drag succeeds, but afterwards Firefox tries to go to http://anything (because that's the text content of the drag), which it then updates to http://anything.com, which does exist.

This problem does not occur on Chrome.