### PR TITLE
Dependency babel-plugin-transform-object-rest-spread, no more needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,26 +126,6 @@ Install the addon:
 
     ember i ember-drag-sort
 
-You'll also need to install a dependency with either npm:
-
-    npm i -D babel-plugin-transform-object-rest-spread
-
- or Yarn:
-
-    yarn add -D babel-plugin-transform-object-rest-spread
-
-Finally, add this to your `ember-cli-build.js`:
-
-```js
-  babel: {
-    plugins: [
-      'transform-object-rest-spread'
-    ]
-  }
-```
-
-
-
 ## Usage
 
 ### Basic usage


### PR DESCRIPTION
Dependency babel-plugin-transform-object-rest-spread, no more needed, because using ember-cli-babel 7 and above.